### PR TITLE
Activity Log wiring + acceptance-test tweaks (chunk 1 of #17)

### DIFF
--- a/iBanker/Model/GameSession.swift
+++ b/iBanker/Model/GameSession.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import SwiftData
 
 class GameSession: ObservableObject {
     @AppStorage("gamePlayers") private var playersData: Data = Data()
@@ -22,7 +23,12 @@ class GameSession: ObservableObject {
     // If you plan to have multiple GameSessions (e.g., different saved games),
     // you might want to pass SettingsStore as an initializer parameter.
     var settings: SettingsStore = SettingsStore() // Create or get your shared settings instance
-    
+
+    // SwiftData context for the Activity Log, injected from the view layer (see
+    // MainTabView). Optional because GameSession is created before the SwiftData
+    // container exists in the environment.
+    var modelContext: ModelContext?
+
     var currentState: GameState {
         GameStateReducer.reduce(players: players, transactions: transactions)
     }
@@ -68,6 +74,45 @@ class GameSession: ObservableObject {
             note: nil
         )
         transactions.append(tx)
+        logActivity(for: action, by: playerID, at: tx.timestamp)
+    }
+
+    // MARK: - Activity Log
+    // The Activity Log is a derived side effect of the transaction log: each
+    // performed action is also recorded as a human-readable ActivityLogEntry in
+    // SwiftData. `perform` stays the single source of truth — the log is never a
+    // second source of state.
+    private func logActivity(for action: GameAction, by playerID: String, at timestamp: Date) {
+        guard let modelContext else { return }
+        guard let description = activityDescription(for: action, by: playerID) else { return }
+        modelContext.insert(ActivityLogEntry(description, timestamp: timestamp))
+    }
+
+    private func playerName(for id: String) -> String {
+        players.first(where: { $0.id == id })?.name ?? "A player"
+    }
+
+    // Returns a human-readable sentence for the action, or nil to skip logging.
+    // `updateSalary` is intentionally not logged: the salary field syncs on every
+    // keystroke, which would flood the log.
+    private func activityDescription(for action: GameAction, by playerID: String) -> String? {
+        let name = playerName(for: playerID)
+        switch action {
+        case .collectSalary(let amount):
+            return "\(name) collected $\(amount) salary."
+        case .payPlayer(let recipientID, let amount):
+            return "\(name) sent $\(amount) to \(playerName(for: recipientID))."
+        case .addMoney(let amount):
+            return "\(name) added $\(amount)."
+        case .subtractMoney(let amount):
+            return "\(name) subtracted $\(amount)."
+        case .resetPlayer(let balance, let salary):
+            return "\(name) was reset to $\(balance) and $\(salary) salary."
+        case .updateSalary:
+            return nil
+        case .custom(let description):
+            return description
+        }
     }
     
     /// Example of how you might implement undo (simplistic, real undo is more complex)

--- a/iBanker/Store/SettingsStore.swift
+++ b/iBanker/Store/SettingsStore.swift
@@ -24,7 +24,7 @@ class SettingsStore: ObservableObject {
     @AppStorage("soundEffects") var soundEffects = true
 
     // New properties for Game Mode settings
-    @AppStorage("selectedGameMode") var selectedGameMode: GameMode = .zero
+    @AppStorage("selectedGameMode") var selectedGameMode: GameMode = .fifteenHundred
     @AppStorage("customInitialBalance") var customInitialBalance: Int = 0
     @AppStorage("customInitialSalary") var customInitialSalary: Int = 0
 
@@ -48,7 +48,7 @@ class SettingsStore: ObservableObject {
     
     func resetAllSettings() {
         soundEffects = true
-        selectedGameMode = .zero
+        selectedGameMode = .fifteenHundred
         customInitialBalance = 0 // Reset custom values
         customInitialSalary = 0
     }

--- a/iBanker/View/MainTabView.swift
+++ b/iBanker/View/MainTabView.swift
@@ -6,9 +6,13 @@
 //
 
 import SwiftUI
+import SwiftData
 
 // MARK: - Main Tab Bar View
 struct MainTabView: View {
+    @EnvironmentObject private var gameSession: GameSession
+    @Environment(\.modelContext) private var modelContext
+
     // State to keep track of the currently selected tab
     @State private var selectedTab: Tab = .home
 
@@ -40,6 +44,11 @@ struct MainTabView: View {
         }
         // Apply the accent color to the selected tab item
         .accentColor(.accentColor) // Using .accentColor will pick up the accent color defined in your Asset Catalog or the system default
+        // Hand the shared GameSession the SwiftData context so performed actions
+        // are recorded to the Activity Log (see GameSession.perform).
+        .task {
+            gameSession.modelContext = modelContext
+        }
     }
 }
 
@@ -53,4 +62,6 @@ enum Tab {
 
 #Preview {
     MainTabView()
+        .environmentObject(GameSession())
+        .modelContainer(for: ActivityLogEntry.self, inMemory: true)
 }

--- a/iBanker/View/PlayerView.swift
+++ b/iBanker/View/PlayerView.swift
@@ -107,6 +107,7 @@ struct PlayerView: View {
                             .multilineTextAlignment(.trailing)
                         Button {
                             gameSession.perform(.addMoney(amount: addAmount), by: player.id)
+                            addInput = nil
                         } label: {
                             Image(systemName: "plus.circle.fill")
                                 .font(.title)
@@ -126,6 +127,7 @@ struct PlayerView: View {
                             .multilineTextAlignment(.trailing)
                         Button {
                             gameSession.perform(.subtractMoney(amount: subtractAmount), by: player.id)
+                            subtractInput = nil
                         } label: {
                             Image(systemName: "minus.circle.fill")
                                 .font(.title)
@@ -164,6 +166,7 @@ struct PlayerView: View {
                             Button {
                                 if let selectedPlayer = selectedPlayer {
                                     gameSession.perform(.payPlayer(selectedPlayer.id, amount: sendAmount), by: player.id)
+                                    sendInput = nil
                                 }
                             } label: {
                                 Image(systemName: "arrow.up.circle.fill")

--- a/iBanker/iBankerApp.swift
+++ b/iBanker/iBankerApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 @main
 struct iBankerApp: App {
@@ -21,5 +22,8 @@ struct iBankerApp: App {
                     gameSession.saveGame()
                 }
         }
+        // Provide the SwiftData container for the Activity Log. Without this the
+        // Activity tab's @Query has no container and crashes at runtime.
+        .modelContainer(for: ActivityLogEntry.self)
     }
 }


### PR DESCRIPTION
## Summary

First chunk of #17 (complete the Swift/SwiftUI conversion): wire the **Activity Log** to the transaction log — plus two small **acceptance-test tweaks** found during simulator testing.

Before this change SwiftData was entirely unwired — there was no `.modelContainer(...)` at runtime, so `ActivityLogView`'s `@Query` **crashed the Activity tab**. This change adds the container and feeds the log from the single source of truth.

## Changes

### Activity Log (§1)
- **`iBankerApp.swift`** — add `.modelContainer(for: ActivityLogEntry.self)` on the `WindowGroup`. Fixes the Activity-tab crash (the `@Query` now has a container).
- **`MainTabView.swift`** — read `@Environment(\.modelContext)` and inject it into the shared `GameSession` via `.task`.
- **`GameSession.swift`** — add `modelContext`; `perform(_:by:)` now also inserts a human-readable, timestamped `ActivityLogEntry`. A helper formats each `GameAction` into a sentence, resolving `playerID → name` (e.g. "Alice sent $50 to Bob.").

### Acceptance-test tweaks (from simulator testing)
- **`SettingsStore.swift`** — default `selectedGameMode` to **`.fifteenHundred`** ($1500 balance, $200 salary), including in `resetAllSettings()`.
- **`PlayerView.swift`** — clear the **Add / Subtract / Send** amount field after the action, so there's clear feedback it occurred (the Salary field is left as-is).

The log is a **derived side effect** of `perform` — `GameSession` stays the single source of truth; the log is never a second source of state.

## Scope decisions (intentional)
- `updateSalary` is **not** logged — the salary field fires it on every keystroke, which would flood the log.
- `ActivityLogEntry` schema kept flat (`event: String` + `timestamp`) for parity with v1.3.0's sentence log; enrichment (playerID/type/amount) deferred.
- Player-created / photo-set logging deferred.
- Known future cleanup (out of scope): `undoLastTransaction()` / `clearAllLogs()` don't reconcile the two stores.

## Testing
- Builds clean with the AGENTS.md build command.
- Simulator (iPhone 17): app launches; **Activity tab renders without crashing**; actions produce readable timestamped entries; amount fields clear after Add/Subtract/Send. (Note: the $1500 default only appears on a fresh install or after "Reset All Settings", since `@AppStorage` keeps any existing stored mode.)

Part of #17 (does not close it).
