### PR TITLE
Consolidate money formatters; fix Custom-mode entry (single Done, empty-not-zero) (#37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ iBanker is being rewritten in SwiftUI and adopts Fast Five Products LLC's public
 
 ## Build Command
 ```bash
-xcodebuild build -project iBanker.xcodeproj -scheme "iBanker" -destination 'platform=iOS Simulator,name=iPhone 17' -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES -quiet
+xcodebuild build -project iBanker.xcodeproj -scheme "default" -destination 'platform=iOS Simulator,name=iPhone 17' -sdk iphonesimulator ONLY_ACTIVE_ARCH=YES -quiet
 ```
-- The active (and only) Xcode project is `iBanker.xcodeproj` (target/scheme `iBanker`, bundle id `com.maiser.ibanker`). Passing `-project iBanker.xcodeproj` is not strictly required now that the repo has a single project, but keep it explicit for clarity.
+- The active (and only) Xcode project is `iBanker.xcodeproj` (target `iBanker`, shared scheme `default` — the FFP convention, matching the template's build command; bundle id `com.maiser.ibanker`). Passing `-project iBanker.xcodeproj` is not strictly required now that the repo has a single project, but keep it explicit for clarity.
 
 
 ## What This App Is
@@ -44,7 +44,7 @@ Both files are template v0.4.0 adoptions: entries are **retention-capped** (`Act
 - `MainTabView` (template-skeleton merge file) owns the `NavigationStack`, the Home / Activity / Settings tabs, the brand navigation title, the `mainToolbar` extension (Edit / Spin-to-Win / Add Player, gated on the Home tab), and the add-player/spinner sheets. Per-tab `navigationTitle`/`toolbar` preferences do NOT propagate through a `TabView` to the enclosing stack — put per-tab bar items in `mainToolbar`, not in tab content.
 - `HomeView` (merge-pattern body) is the player roster: lists/edits players (delete, reorder) and shows live balances; presents `PlayerView` pushes. **Edit mode** (`@Binding editMode`) is owned by `MainTabView` (its `mainToolbar` Edit/Done button) but injected with `.environment(\.editMode, …)` at the **List level here** — injecting it on the `TabView` does not activate a tab-hosted List (#30). Swipe-to-delete is armed only in Edit mode, and a player who has exchanged money (`GameSession.hasExchangedMoney`) is locked from individual deletion (roster deletes go through `GameSession`, which keeps the transaction log and appends an Activity Log marker; **Delete All Players** in Settings additionally clears the transaction log for a fresh start).
 - `PlayerView` is the per-player banking screen (collect salary, add/subtract, send to another player).
-- `ViewSupport/` holds presentation config aligned with the template: `AppConfig` (merge file — brand, `dynamicSizeMax`, colors), `CustomLabeledContentStyle`, `ErrorAlertViewModifier`, plus app-owned `PlayerThumbnailView`/`CameraImagePicker`/`KeyboardDoneToolbar` (the shared number-pad "Done" keyboard accessory, #35 — apply once per screen).
+- `ViewSupport/` holds presentation config aligned with the template: `AppConfig` (merge file — brand, `dynamicSizeMax`, colors), `CustomLabeledContentStyle`, `ErrorAlertViewModifier`, plus app-owned `PlayerThumbnailView`/`CameraImagePicker`/`KeyboardDoneToolbar` (the shared number-pad "Done" keyboard accessory, #35/#37 — pushed screens and sheets attach it once at Form/container level; in a TAB-hosted Form it renders only from inside a list cell, attached to exactly ONE row — see the placement rules in that file) and `IntegerFormatter` (the one shared money-entry `NumberFormatter`, #37).
 - `Utilities/` — template `DebugLogging` (the `DebugPrintable` protocol's `debugprint(_:)`, release no-op, plus `deviceLog`), template `PreviewConfig` (`isPreview`), and app-owned `SoundPlayer`/`PlayerImageMaker`.
 
 

--- a/iBanker/View/AddNewPlayerView.swift
+++ b/iBanker/View/AddNewPlayerView.swift
@@ -2,7 +2,7 @@
 //  AddNewPlayerView.swift
 //
 //  Created by Elizabeth Maiser, Fast Five Products LLC, on 7/22/25.
-//  Modified by Pete Maiser, Fast Five Products LLC, on 7/9/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/10/26.
 //
 //  Copyright © 2025, 2026 Fast Five Products LLC. All rights reserved.
 //
@@ -43,17 +43,7 @@ struct AddNewPlayerView: View {
 
     // A closure to pass the new Player object back to the HomeView.
     var onSave: (Player) -> Void
-    
-    // Formatter for the playerSalary field (integers only)
-    private var integerFormatter: NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .none
-        formatter.usesGroupingSeparator = false
-        formatter.generatesDecimalNumbers = false
-        formatter.maximumFractionDigits = 0
-        return formatter
-    }
-    
+
     var body: some View {
         NavigationStack {
             Form {
@@ -96,7 +86,7 @@ struct AddNewPlayerView: View {
                         Text("Balance:")
                         HStack(spacing: 0) {
                             Text("$")
-                            TextField("Initial Balance", value: $playerBalance, formatter: integerFormatter)
+                            TextField("Initial Balance", value: $playerBalance, formatter: NumberFormatter.integer)
                                 .keyboardType(.numberPad)
                                 .autocorrectionDisabled()
                                 .focused($focusedField, equals: .balance)
@@ -107,7 +97,7 @@ struct AddNewPlayerView: View {
                         Text("Salary:")
                         HStack(spacing: 0) {
                             Text("$")
-                            TextField("Initial Salary", value: $playerSalary, formatter: integerFormatter)
+                            TextField("Initial Salary", value: $playerSalary, formatter: NumberFormatter.integer)
                                 .keyboardType(.numberPad)
                                 .autocorrectionDisabled()
                                 .focused($focusedField, equals: .salary)
@@ -171,6 +161,8 @@ struct AddNewPlayerView: View {
                         self.playerSalary = settings.effectiveDefaultSalary
                     }
                 }
+                // Open ready to type the name (#37 rider)
+                focusedField = .name
             }
         }
     }

--- a/iBanker/View/GameModeSection.swift
+++ b/iBanker/View/GameModeSection.swift
@@ -2,7 +2,7 @@
 //  GameModeSection.swift
 //
 //  Created by Pete Maiser, Fast Five Products LLC, on 7/7/26.
-//  Modified by Pete Maiser, Fast Five Products LLC, on 7/9/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/10/26.
 //
 //  Copyright © 2026 Fast Five Products LLC. All rights reserved.
 //
@@ -25,14 +25,32 @@ struct GameModeSection: View {
     // For logging a mode change to the Activity Log (see the picker binding).
     @EnvironmentObject private var gameSession: GameSession
 
-    // Keyboard focus (#35): the custom-mode number pads dismiss via the shared
-    // keyboardDoneToolbar. Owned here so both hosts (Settings tab and the
-    // empty-state Game Mode sheet) get it; neither hosts other text fields,
-    // so there's no toolbar collision.
+    // Keyboard focus (#35, reworked twice in #37): owned here, with the Done
+    // accessory attached to exactly ONE row below — see that comment. Serves
+    // both hosts (Settings tab and the empty-state Game Mode sheet).
     private enum Field {
         case balance, salary
     }
     @FocusState private var focusedField: Field?
+
+    // The custom values are stored as non-optional Ints (0 = unset), but the
+    // fields bind optionals so an unset value shows the placeholder instead
+    // of a stuck "0" — matching every other money field (#37). A deliberate
+    // consequence: a stored 0 displays as empty, which is equivalent here.
+    // (Clear-then-commit redisplays the old value — empty text doesn't parse,
+    // so set(nil) doesn't fire; same as every other money field. Type 0 to unset.)
+    private var customBalanceBinding: Binding<Int?> {
+        Binding(
+            get: { settings.customInitialBalance == 0 ? nil : settings.customInitialBalance },
+            set: { settings.customInitialBalance = $0 ?? 0 }
+        )
+    }
+    private var customSalaryBinding: Binding<Int?> {
+        Binding(
+            get: { settings.customInitialSalary == 0 ? nil : settings.customInitialSalary },
+            set: { settings.customInitialSalary = $0 ?? 0 }
+        )
+    }
 
     var body: some View {
         Section("Game Mode Defaults") {
@@ -60,17 +78,25 @@ struct GameModeSection: View {
                 HStack {
                     Text("Default Balance")
                     Spacer()
-                    TextField("Custom Initial Balance", value: $settings.customInitialBalance, formatter: NumberFormatter())
+                    TextField("Initial Balance", value: customBalanceBinding, formatter: NumberFormatter.integer)
                         .keyboardType(.numberPad)
                         .autocorrectionDisabled()
                         .multilineTextAlignment(.trailing)
                         .focused($focusedField, equals: .balance)
                 }
+                // Done accessory on this ONE row only (#37): in a tab-hosted
+                // Form, keyboard toolbar items reach the keyboard only when
+                // declared inside a list cell (Form-level and mainToolbar
+                // attachments never render — #30's propagation gap), and every
+                // cell's declaration contributes a button simultaneously (the
+                // multiple-Done bug when this sat on the whole Section). One
+                // row = one Done; it shows for either field's keyboard.
+                .keyboardDoneToolbar(focus: $focusedField)
 
                 HStack {
                     Text("Default Salary")
                     Spacer()
-                    TextField("Custom Initial Salary", value: $settings.customInitialSalary, formatter: NumberFormatter())
+                    TextField("Initial Salary", value: customSalaryBinding, formatter: NumberFormatter.integer)
                         .keyboardType(.numberPad)
                         .autocorrectionDisabled()
                         .multilineTextAlignment(.trailing)
@@ -99,7 +125,6 @@ struct GameModeSection: View {
             // above, not here.)
             settings.enabledSpinner = settings.selectedGameMode.defaultSpinnerOn
         }
-        .keyboardDoneToolbar(focus: $focusedField)
     }
 }
 

--- a/iBanker/View/PlayerView.swift
+++ b/iBanker/View/PlayerView.swift
@@ -2,7 +2,7 @@
 //  PlayerView.swift
 //
 //  Created by Elizabeth Maiser, Fast Five Products LLC, on 7/22/25.
-//  Modified by Pete Maiser, Fast Five Products LLC, on 7/9/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/10/26.
 //
 //  Copyright © 2025, 2026 Fast Five Products LLC. All rights reserved.
 //
@@ -63,16 +63,6 @@ struct PlayerView: View {
     private var sendAmount: Int {
         Int(sendInput ?? 0)    }
     
-    // Formatter for the playerSalary field (integers only)
-    private var integerFormatter: NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .none
-        formatter.usesGroupingSeparator = false
-        formatter.generatesDecimalNumbers = false
-        formatter.maximumFractionDigits = 0
-        return formatter
-    }
-    
     var body: some View {
         VStack {
             // Tappable photo opens the shared change/add/remove flow; the camera badge signals editability.
@@ -129,7 +119,7 @@ struct PlayerView: View {
 
                             Spacer()
 
-                            TextField("Enter Salary", value: $salaryInput, formatter: integerFormatter)
+                            TextField("Enter Salary", value: $salaryInput, formatter: NumberFormatter.integer)
                                 .font(.title2)
                                 .fontWeight(.bold)
                                 .keyboardType(.numberPad)
@@ -150,7 +140,7 @@ struct PlayerView: View {
                     HStack {
                         Text("Add $:")
                         Spacer()
-                        TextField("Enter Amount", value: $addInput, formatter: integerFormatter)
+                        TextField("Enter Amount", value: $addInput, formatter: NumberFormatter.integer)
                             .keyboardType(.numberPad)
                             .autocorrectionDisabled(true)
                             .multilineTextAlignment(.trailing)
@@ -170,7 +160,7 @@ struct PlayerView: View {
                     HStack {
                         Text("Subtract $:")
                         Spacer()
-                        TextField("Enter Amount", value: $subtractInput, formatter: integerFormatter)
+                        TextField("Enter Amount", value: $subtractInput, formatter: NumberFormatter.integer)
                             .keyboardType(.numberPad)
                             .autocorrectionDisabled(true)
                             .multilineTextAlignment(.trailing)
@@ -189,7 +179,7 @@ struct PlayerView: View {
                         HStack {
                             Text("Send Amount:")
                             Spacer()
-                            TextField("Enter Amount", value: $sendInput, formatter: integerFormatter)
+                            TextField("Enter Amount", value: $sendInput, formatter: NumberFormatter.integer)
                                 .keyboardType(.numberPad)
                                 .autocorrectionDisabled(true)
                                 .multilineTextAlignment(.trailing)

--- a/iBanker/View/SettingsView.swift
+++ b/iBanker/View/SettingsView.swift
@@ -2,7 +2,7 @@
 //  SettingsView.swift
 //
 //  Template file created by Elizabeth Maiser, Fast Five Products LLC, on 7/4/25.
-//  Modified by Pete Maiser, Fast Five Products LLC, on 7/9/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/10/26.
 //
 //  Template v0.3.0 (updated) — Fast Five Products LLC's public AGPL template.
 //
@@ -57,7 +57,8 @@ struct SettingsView: View {
                     Toggle("Spin-to-Win Spinner", isOn: $settings.enabledSpinner)
                 }
                 // Shared with the empty-state "Game Mode" sheet (#31); the
-                // mode → spinner reset lives inside GameModeSection.
+                // mode → spinner reset (and the custom fields' keyboard Done
+                // accessory, #37) live inside GameModeSection.
                 GameModeSection()
                 // Destructive-settings section (#28, extended #30), mirroring
                 // iOS Settings > General > Reset: red buttons, each confirmed,

--- a/iBanker/ViewSupport/IntegerFormatter.swift
+++ b/iBanker/ViewSupport/IntegerFormatter.swift
@@ -1,0 +1,29 @@
+//
+//  IntegerFormatter.swift
+//
+//  Created by Claude, Fast Five Products LLC, on 7/10/26.
+//
+//  Copyright © 2026 Fast Five Products LLC. All rights reserved.
+//
+//  This file is part of a project licensed under the GNU Affero General Public License v3.0.
+//  See the LICENSE file at the root of this repository for full terms.
+//
+//  An exception applies: Fast Five Products LLC retains the right to use this code and
+//  derivative works in proprietary software without being subject to the AGPL terms.
+//  See LICENSE-EXCEPTIONS.md for details.
+//
+
+import Foundation
+
+extension NumberFormatter {
+    /// The app's one money-entry formatter: plain integers — no grouping
+    /// separators, no decimals. Shared by every money TextField (#37).
+    static let integer: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.usesGroupingSeparator = false
+        formatter.generatesDecimalNumbers = false
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+}

--- a/iBanker/ViewSupport/KeyboardDoneToolbar.swift
+++ b/iBanker/ViewSupport/KeyboardDoneToolbar.swift
@@ -2,6 +2,7 @@
 //  KeyboardDoneToolbar.swift
 //
 //  Created by Claude, Fast Five Products LLC, on 7/9/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/10/26.
 //
 //  Copyright © 2026 Fast Five Products LLC. All rights reserved.
 //
@@ -15,18 +16,35 @@
 
 import SwiftUI
 
+/// A "Done" accessory above the keyboard that clears the given focus to
+/// dismiss it — the standard system answer to number pads having no Return
+/// key (#35). Placement rules, established empirically in #35/#37 (each
+/// wrong placement was shipped once):
+/// - Pushed screens and sheets: apply `.keyboardDoneToolbar(focus:)` once,
+///   on the screen's Form/List/container itself.
+/// - TAB-hosted Forms (e.g. SettingsView): Form-level and mainToolbar
+///   attachments never render — keyboard toolbar items reach the keyboard
+///   only when declared inside a list cell. Attach to exactly ONE row:
+///   every row's declaration contributes a button simultaneously, so a
+///   multi-row (Section-level) attachment shows multiple Done buttons.
+/// #6's K/M/000 shortcut buttons would extend this same accessory.
+struct KeyboardDoneToolbar<Field: Hashable>: ToolbarContent {
+    var focus: FocusState<Field?>.Binding
+
+    var body: some ToolbarContent {
+        ToolbarItemGroup(placement: .keyboard) {
+            Spacer()
+            Button("Done") { focus.wrappedValue = nil }
+        }
+    }
+}
+
 extension View {
-    /// A "Done" accessory above the keyboard that clears the given focus to
-    /// dismiss it — the standard system answer to number pads having no Return
-    /// key (#35). Apply once per screen: a second keyboard toolbar in the same
-    /// hierarchy would duplicate the button. Shared by every numeric-entry
-    /// screen; #6's K/M/000 shortcut buttons would extend this same accessory.
+    /// Attach the shared Done accessory to a pushed/sheet screen's container
+    /// (see KeyboardDoneToolbar's placement rules).
     func keyboardDoneToolbar<Field: Hashable>(focus: FocusState<Field?>.Binding) -> some View {
         toolbar {
-            ToolbarItemGroup(placement: .keyboard) {
-                Spacer()
-                Button("Done") { focus.wrappedValue = nil }
-            }
+            KeyboardDoneToolbar(focus: focus)
         }
     }
 }


### PR DESCRIPTION
## Summary

Executes #37 (formatter consolidation) plus the two Custom-mode entry defects the owner assigned to it at the #35 gate, and two rider requests:

- **One shared money formatter** — `NumberFormatter.integer` (new `ViewSupport/IntegerFormatter.swift`, static instance); both duplicated per-view formatters deleted, all 8 call sites retrofitted. Custom-mode fields now parse identically to every other money field.
- **Single Done button on the Custom fields** — keyboard-toolbar placement rules established empirically and recorded in `KeyboardDoneToolbar.swift` + `AGENTS.md`: pushed screens/sheets attach at Form level; a TAB-hosted Form renders only in-cell declarations (Form-level and mainToolbar never render), and every cell contributes a button — so the accessory now sits on exactly ONE row inside `GameModeSection`, serving both hosts.
- **Empty-not-zero** — optional-backed `Binding<Int?>` shims over the non-optional `@AppStorage` custom values; unset shows the placeholder, matching the other money fields.
- **Riders** — placeholders trimmed to "Initial Balance"/"Initial Salary"; Add New Player opens focused on the Name field; `AGENTS.md` build command now names the shared `default` scheme (FFP convention, matching template.ios).

## Release-note draft

Custom game mode entry cleaned up: one Done button above the keyboard, empty fields show hints instead of a stuck 0, and the fields parse amounts exactly like the rest of the app; adding a player now starts in the Name field, ready to type.

## Test plan

Owner-verified on a physical iPhone: single Done in the Settings tab and the empty-state Game Mode sheet, placeholder behavior, typed values persist; PlayerView/Add-Player money fields regression-checked. Adversarial review: 18 candidates refuted, 1 plausible dispositioned as consistent-by-design (clear-then-commit redisplays the old value — same as every money field; documented in code). Builds warning-free with the AGENTS.md command.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)