### PR TITLE
v2.0.0 submission prep: build 2; App Store listing (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Player **balances and salaries are never stored directly**. `gameSession.current
 **Consequence for any money/salary change:** append a transaction via `gameSession.perform(action, by: playerID)` — never mutate a balance directly. Views read balances through `gameSession.currentState.playerBalances[player.id]`. `PlayerView` is where all the user-facing `GameAction`s originate.
 
 ### Persistence
-- `GameSession` JSON-encodes `players` and `transactions` into `@AppStorage` (UserDefaults keys `gamePlayers` / `gameTransactions`). It is saved on the root view's `onDisappear` and decoded in `GameSession.init()` (direct `UserDefaults` access, to satisfy two-phase init).
+- `GameSession` JSON-encodes `players` and `transactions` into `@AppStorage` (UserDefaults keys `gamePlayers` / `gameTransactions`). It is saved deterministically whenever the scene leaves the foreground (`scenePhase` → `.background`/`.inactive` in `iBankerApp`, #38 — the root view's `onDisappear` remains as belt-and-braces but never fires on backgrounding) and decoded in `GameSession.init()` (direct `UserDefaults` access, to satisfy two-phase init).
 - `SettingsStore` persists individual settings via `@AppStorage` (`selectedGameMode`, `customInitialBalance`, `customInitialSalary`, `soundEffects`, `enabledSpinner`).
 - `GameMode` defines preset starting balances/salaries per popular game; `SettingsStore.effectiveDefaultBalance/Salary` resolve the active mode (or custom values).
 

--- a/iBanker.xcodeproj/project.pbxproj
+++ b/iBanker.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B534D2572FED28BE003FD983 /* Exceptions for "iBanker" folder in "iBanker" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				"app-store-listing.md",
 				Info.plist,
 			);
 			target = B546DF0C1BDBCC360006D303 /* iBanker */;
@@ -275,7 +276,7 @@
 				CLANG_CXX_LIBRARY = "$(inherited)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iBanker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -300,7 +301,7 @@
 				CLANG_CXX_LIBRARY = "$(inherited)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iBanker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/iBanker/View/SettingsView.swift
+++ b/iBanker/View/SettingsView.swift
@@ -2,7 +2,7 @@
 //  SettingsView.swift
 //
 //  Template file created by Elizabeth Maiser, Fast Five Products LLC, on 7/4/25.
-//  Modified by Pete Maiser, Fast Five Products LLC, on 7/11/26.
+//  Modified by Pete Maiser, Fast Five Products LLC, on 7/12/26.
 //
 //  Template v0.3.0 (updated) — Fast Five Products LLC's public AGPL template.
 //
@@ -167,7 +167,7 @@ struct SettingsView: View {
         }
     }
 
-    /// "2.0 (1)" — marketing version and build, from the bundle.
+    /// e.g. "2.0.0 (2)" — marketing version and build, from the bundle.
     private static var appVersion: String {
         let info = Bundle.main.infoDictionary
         let version = info?["CFBundleShortVersionString"] as? String ?? "—"

--- a/iBanker/app-store-listing.md
+++ b/iBanker/app-store-listing.md
@@ -1,0 +1,55 @@
+# App Store Listing — iBanker
+
+## Promotional Text (170 characters max)
+
+Celebrating 10 years of iBanker — rebuilt from the ground up! Replace the paper money in board games like Monopoly® and The Game of Life®.
+
+## Description (4000 characters max)
+
+Avoid the hassle of counting cash — keep the paper money in the box and use iBanker instead! Send money to and from "the bank" or directly from one player to another: iBanker completely replaces paper money and the job of "banker" in board games.
+
+Now celebrating its 10th year on the App Store, iBanker 2.0 is a complete ground-up rebuild — a fresh, modern app for iPhone and iPad, with Dark Mode, larger-text support, and the same fast table-side banking families have used for a decade.
+
+**Players, Made Personal**
+Add and manage players with an easy interface — including a photo for each player, taken with the camera or chosen from your library. Every balance stays in view on the roster, formatted like real money.
+
+**One-Tap Banking**
+Type an amount and tap once — Add, Subtract, or Send, right from the keyboard. Sending money starts with picking the player, so transfers are quick between turns. Collect Salary keeps payday to a single tap.
+
+**Every Move on the Record**
+The Activity Log records every transaction in plain language, and the whole game saves automatically — take a break, switch apps, or come back days later and pick up right where you left off.
+
+**Game Modes**
+Change the Mode in Settings to automatically match the starting bank value of the most popular games — $0, $1,500, $10,000, $400,000, or $15,000,000 — or set your own Custom values. When you are ready to start a new game, Reset Players returns everyone to the starting value.
+
+**Spin to Win®**
+The Spinner provides the Spin to Win® function for the electronic banking version of The Game of Life®. It is automatically enabled for the $400,000 Mode.
+
+Monopoly and The Game of Life are registered trademarks of Hasbro, Inc. Spin to Win is a registered trademark of The Trustee of the Reuben B. Klamer L.T. The author of this application is not affiliated with those trademark owners, nor is this application endorsed by, supported by, or in any other way connected with those registered trademark owners.
+
+## What's New in This Version (4000 characters max)
+
+iBanker 2.0 — the 10th Anniversary Edition — is a complete rebuild of the app from the ground up:
+
+- A fresh, modern design for iPhone and iPad, with Dark Mode and larger-text support
+- Player photos — take one with the camera or choose from your library
+- One-tap money entry right from the keyboard: Add, Subtract, and Send
+- Activity Log that records every move in plain language
+- Change settings for different game types, reset player balances
+
+## Categories
+
+Primary: Games — Board
+Secondary: Entertainment
+
+## Keywords (100 characters max)
+
+board game, banker, monopoly, game of life, family game, ibanker, calculator
+
+## Support URL
+
+https://ibanker.fastfiveproducts.com
+
+## Copyright
+
+© 2015–2026 Fast Five Products LLC


### PR DESCRIPTION
## Summary

Unblocks the v2.0.0 App Store submission and versions the listing in the repo:

- **Build 2** — `CURRENT_PROJECT_VERSION` 1 → 2 in both configurations, resolving ASC's *Redundant Binary Upload* rejection (build string "1" was consumed by the earlier `2.0 (1)` test upload). Built product verified `2.0.0 (2)`.
- **`iBanker/app-store-listing.md`** — the versioned ASC listing (10-year-anniversary promotional hook; owner-wordsmithed description and What's New; Categories: Games — Board primary, Entertainment secondary; keywords 76/100; support URL corrected to the `.com` domain; © 2015–2026 Fast Five Products LLC). Deviation from the issue body, owner-directed: placed under `iBanker/` (Xcode-visible via the synchronized folder, with a membership exception so it does NOT ship in the app bundle — verified) instead of `web/`, which is reserved for future cross-platform components.
- **Riders** (flagged): AGENTS.md persistence section updated to the #38 scenePhase truth; SettingsView `appVersion` doc example refreshed; two Xcode-written inert `INFOPLIST_KEY_*` duplicates removed (the #39 class — the category and display name are already live from Info.plist, verified in the built product).

Adversarial (consistency) review: 21 findings — 17 confirmed the listing's claims against the actual app; the one refutation (a What's New bullet claiming v1.3.0-era modes as new) fixed pre-commit; character limits verified empirically.

After merge, the owner-approved release mechanics apply: **amend `main`'s `Release v2.0.0`** with this delta (pre-submission, preserves one-commit-per-release) and re-verify `main..develop` is empty.

## Release-note draft

Version 2.0.0 ships as build 2 with the App Store listing refreshed for iBanker's 10-year anniversary; the listing now lives in the repo alongside the app.

## Test plan

Built product verified via plutil: `CFBundleVersion` 2, `CFBundleShortVersionString` 2.0.0, category and name intact, listing absent from the bundle. Character limits counted (`wc -m`): promo 138/170, keywords 76/100, description/What's New well under 4000. Owner is archiving, validating, and distributing to App Store Connect from this change before the merge — that upload is the end-to-end acceptance test for the build-number fix.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
